### PR TITLE
Clarified Basis User Id replacement

### DIFF
--- a/basisdataexport.php
+++ b/basisdataexport.php
@@ -16,7 +16,7 @@
 ////////////////////////////////////
 
 // Specify your Basis user id
-$basis_userid = '[ ADD YOUR BASIS USER ID HERE ]';
+$basis_userid = 'ADD YOUR BASIS USER ID HERE';
 
 // Debug flag
 $debug = false;


### PR DESCRIPTION
The original code makes it seem like the User Id should go within the brackets, rather than replace the entire string. I think removing the brackets makes it more clear that the User Id should replace the entire string.
